### PR TITLE
Fixed issue with copying libraries.

### DIFF
--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -85,5 +85,5 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     )
 endif()
 
-# Create an install command to install the shared libs.
-copy_truss_libraries(bgfx_EXTERNAL "${bgfx_LIBRARIES_DIR}")
+# Create install commands to install the shared libs.
+copy_truss_libraries(bgfx_EXTERNAL "${bgfx_LIBRARY}")

--- a/cmake/physfs.cmake
+++ b/cmake/physfs.cmake
@@ -38,4 +38,4 @@ set_target_properties(physfs PROPERTIES
 )
 
 # Create an install command to install the shared libs.
-copy_truss_libraries(physfs_EXTERNAL "${physfs_LIBRARIES_DIR}")
+copy_truss_libraries(physfs_EXTERNAL "${physfs_LIBRARY}")

--- a/cmake/sdl.cmake
+++ b/cmake/sdl.cmake
@@ -46,4 +46,4 @@ set_target_properties(sdl PROPERTIES
 )
 
 # Create an install command to install the shared libs.
-copy_truss_libraries(sdl_EXTERNAL "${sdl_LIBRARIES_DIR}")
+copy_truss_libraries(sdl_EXTERNAL "${sdl_LIBRARY}")

--- a/cmake/terra.cmake
+++ b/cmake/terra.cmake
@@ -28,7 +28,7 @@ ExternalProject_Add(terra_EXTERNAL
 # Recover project paths for additional settings.
 ExternalProject_Get_Property(terra_EXTERNAL SOURCE_DIR)
 
-# On linux systems, fix terra's naming convention.
+# On Linux systems, fix terra's naming convention.
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     add_custom_command(TARGET terra_EXTERNAL
         POST_BUILD
@@ -57,12 +57,15 @@ set_target_properties(terra PROPERTIES
     IMPORTED_IMPLIB "${terra_IMPLIB}"
 )
 
+# Create an install command to install the shared libs.
+copy_truss_libraries(terra_EXTERNAL "${terra_LIBRARY}")
+
 # On Windows, Terra uses a separate Lua library for some reason.
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
-    set(lua51_IMPLIB "${SOURCE_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lua51${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(lua51_LIBRARY "${SOURCE_DIR}/bin/lua51.dll")
+    set(lua51_IMPLIB "${SOURCE_DIR}/lib/lua51.lib")
+    
     set_target_properties(terra PROPERTIES
         INTERFACE_LINK_LIBRARIES "${lua51_IMPLIB}")
+    copy_truss_libraries(terra_EXTERNAL "${lua51_LIBRARY}")
 endif()
-
-# Create an install command to install the shared libs.
-copy_truss_libraries(terra_EXTERNAL "${terra_LIBRARIES_DIR}")

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,9 +1,6 @@
 # Utility functions for building truss.
 # Copies every library in the given path to the `dist` lib directory.
-function(copy_truss_libraries target target_library_path)
-    file(GLOB target_libraries
-        "${target_library_path}/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}*")
-
+function(copy_truss_libraries target target_libraries)
     foreach(library_path ${target_libraries})
         # Extract library name and create a rule to copy it to the `lib` directory.
         get_filename_component(library_file "${library_path}" NAME)


### PR DESCRIPTION
This fixes an issue where `GLOB` was not getting regenerated after external libraries were rebuilt, leading to libraries not getting copied over to `./dist/lib` until CMake was rerun.
