### PR TITLE
Added fix for MacOS rpath.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ endif()
 # Configure the RPATH for Linux and OSX.
 set(CMAKE_SKIP_BUILD_RPATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_MACOSX_RPATH TRUE)
 set_target_properties(truss PROPERTIES
     INSTALL_RPATH "./lib"
     RUNTIME_OUTPUT_DIRECTORY "${DIST_DIR}"

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -2,20 +2,8 @@
 # Copies every library in the given path to the `dist` lib directory.
 function(truss_copy_libraries target target_libraries)
     foreach(library_path ${target_libraries})
-        # Extract library name and create a rule to copy it to the `lib` directory.
+        # Extract library name from full path.
         get_filename_component(library_file "${library_path}" NAME)
-        add_custom_command(
-            TARGET "${target}" POST_BUILD
-            COMMAND "${CMAKE_COMMAND}"
-            ARGS -E copy "${library_path}" "${DIST_DIR}/lib/${library_file}"
-            BYPRODUCTS "${DIST_DIR}/lib/${library_file}"
-            COMMENT "Installed ${target} library to distribution directory."
-        )
-
-        # On Windows, we delay loading for a bit to allow time for an RPATH modification.
-        if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-            set_property(TARGET truss APPEND_STRING PROPERTY LINK_FLAGS "/DELAYLOAD:${library_file} ")
-        endif()
 
         # On Mac, we need to relocate the library RPATH.
         # This is handled manually as a post-build step because of wild
@@ -24,10 +12,24 @@ function(truss_copy_libraries target target_libraries)
             add_custom_command(
                 TARGET "${target}" POST_BUILD
                 COMMAND install_name_tool
-                ARGS -id "@executable_path/lib/${library_file}" "${DIST_DIR}/lib/${library_file}"
-                DEPENDS "${DIST_DIR}/lib/${library_file}"
+                ARGS -id "@executable_path/lib/${library_file}" "${library_path}"
+                DEPENDS "${library_path}"
                 COMMENT "Relocated Mac RPATH of ${target} library."
             )
         endif()
+
+        # On Windows, we delay loading for a bit to allow time for an RPATH modification.
+        if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+            set_property(TARGET truss APPEND_STRING PROPERTY LINK_FLAGS "/DELAYLOAD:${library_file} ")
+        endif()
+
+        # Create a rule to copy the library to the `lib` directory.
+        add_custom_command(
+            TARGET "${target}" POST_BUILD
+            COMMAND "${CMAKE_COMMAND}"
+            ARGS -E copy "${library_path}" "${DIST_DIR}/lib/${library_file}"
+            BYPRODUCTS "${DIST_DIR}/lib/${library_file}"
+            COMMENT "Installed ${target} library to distribution directory."
+        )
     endforeach()
 endfunction()


### PR DESCRIPTION
Because Mac linking is insane, this PR removes the default `rpath` instructions added to each truss dependency library and replaces them with a built-in executable-relative linking path.

This change should have no effect on other platforms.