### PR TITLE
Removed `scripts` from evaluation of argstring.

### DIFF
--- a/dist/scripts/core/bootstrap.t
+++ b/dist/scripts/core/bootstrap.t
@@ -299,7 +299,7 @@ function _coreInit(argstring)
 	_addPaths()
 	-- Load in argstring
 	local t0 = tic()
-	local fn = "scripts/" .. argstring
+	local fn = argstring
 	log.info("Loading " .. fn)
 	local script = loadStringFromFile(fn)
 	local scriptfunc, loaderror = loadNamed(script, argstring)


### PR DESCRIPTION
This removes the default appending of `scripts/` to all startup paths provided to `truss.exe`.