### PR TITLE
Adds a message indicating that CMake install step does nothing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,4 +95,4 @@ set_target_properties(truss PROPERTIES
 )
 
 # If the user attempts to install, politely inform them that it has no effect.
-install(CODE "MESSAGE(\"Truss cannot be installed to the system.\")")
+install(CODE "MESSAGE(WARNING \"\nTruss cannot be installed to the system. Typically, the 'dist' directory is re-distributed as a self-contained application.\")")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,3 +93,6 @@ set_target_properties(truss PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${DIST_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${DIST_DIR}"
 )
+
+# If the user attempts to install, politely inform them that it has no effect.
+install(CODE "MESSAGE(\"Truss cannot be installed to the system.\")")


### PR DESCRIPTION
Previously, calling the CMake install step would throw an error, but adding this message makes it simply print an informative warning message.