### PR TITLE
0.1.1: More flexibility with physFS paths, deferred SDL init

### DIFF
--- a/dist/include/truss_api.h
+++ b/dist/include/truss_api.h
@@ -48,7 +48,7 @@ const char* truss_get_file_real_path(const char* filename);
 truss_message* truss_load_file(const char* filename);
 int truss_save_file(const char* filename, truss_message* data);
 int truss_save_data(const char* filename, const char* data, unsigned int datalength);
-int truss_add_fs_path(const char* path, const char* mountpath, int append);
+int truss_add_fs_path(const char* path, const char* mountpath, int append, int relative);
 int truss_set_fs_savedir(const char* path);
 int truss_set_raw_write_dir(const char* path);
 int truss_list_directory(truss_interpreter_id interpreter, const char* path);

--- a/dist/scripts/core/core.t
+++ b/dist/scripts/core/core.t
@@ -492,7 +492,7 @@ local function add_paths()
       local physicalPath = truss.args[i+1]
       local mountPath = truss.args[i+2]
       log.info(("Adding path %s => %s"):format(physicalPath, mountPath))
-      truss.C.add_fs_path(physicalPath, mountPath, 0)
+      truss.C.add_fs_path(physicalPath, mountPath, 0, 0)
     end
   end
 end

--- a/src/addons/sdl/sdl_addon.h
+++ b/src/addons/sdl/sdl_addon.h
@@ -97,6 +97,7 @@ public:
 	const std::string& getHeader();
 	const std::string& getVersion();
 	void init(truss::Interpreter* owner);
+	void SDLinit();
 	void shutdown();
 	void update(double dt);
 
@@ -131,6 +132,8 @@ private:
 
 	std::string clipboard_;
 	std::string filedrop_;
+
+	bool sdlIsInit_;
 
 	SDL_Window* window_;
 	SDL_Event event_;

--- a/src/truss/core.cpp
+++ b/src/truss/core.cpp
@@ -88,9 +88,12 @@ void Core::initFS(char* argv0, bool mountBaseDir) {
     physFSInitted_ = true;
 }
 
-void Core::addFSPath(const char* pathname, const char* mountname, bool append) {
+void Core::addFSPath(const char* pathname, const char* mountname, bool append, bool relative) {
     std::stringstream ss;
-    ss << PHYSFS_getBaseDir() << PHYSFS_getDirSeparator() << pathname;
+    if(relative){
+        ss << PHYSFS_getBaseDir(); // includes path separator    
+    }
+    ss << pathname;
     logPrint(TRUSS_LOG_DEBUG, "Adding physFS path: %s", ss.str().c_str());
 
     int retval = PHYSFS_mount(ss.str().c_str(), mountname, append);
@@ -131,7 +134,8 @@ void Core::extractLibraries() {
 
 void Core::setWriteDir(const char* writepath) {
     std::stringstream ss;
-    ss << PHYSFS_getBaseDir() << PHYSFS_getDirSeparator() << writepath;
+    // dir separator not needed, included in getBaseDir
+    ss << PHYSFS_getBaseDir() << writepath; 
     logPrint(TRUSS_LOG_DEBUG, "Setting physFS write path: %s", ss.str().c_str());
 
     int retval = PHYSFS_setWriteDir(ss.str().c_str());

--- a/src/truss/core.h
+++ b/src/truss/core.h
@@ -20,7 +20,7 @@ public:
     // functions for dealing with physfs (you can also make direct physfs
     // calls if you need to, after you've called initFS)
     void initFS(char* argv0, bool mountBaseDir=true);
-    void addFSPath(const char* pathname, const char* mountname, bool append=true);
+    void addFSPath(const char* pathname, const char* mountname, bool append=true, bool relative=true);
     void setWriteDir(const char* writepath);
 	void setRawWriteDir(const char* path, bool mount=true);
     void extractLibraries();

--- a/src/truss/trussapi.cpp
+++ b/src/truss/trussapi.cpp
@@ -72,8 +72,8 @@ int truss_save_data(const char* filename, const char* data, unsigned int datalen
 	return 0;
 }
 
-int truss_add_fs_path(const char* path, const char* mountpath, int append) {
-    core().addFSPath(path, mountpath, append);
+int truss_add_fs_path(const char* path, const char* mountpath, int append, int relative) {
+    core().addFSPath(path, mountpath, append > 0, relative > 0);
     return 0;
 }
 

--- a/src/trussapi.h
+++ b/src/trussapi.h
@@ -6,7 +6,7 @@
 #ifndef TRUSSAPI_H_HEADER_GUARD
 #define TRUSSAPI_H_HEADER_GUARD
 
-#define TRUSS_VERSION_STRING "0.1.0"
+#define TRUSS_VERSION_STRING "0.1.1"
 
 #include <cstdint> // Needed for uint64_t etc.
 #include <cstddef> // Needed for size_t etc.
@@ -82,7 +82,7 @@ TRUSS_C_API const char* truss_get_file_real_path(const char* filename);
 TRUSS_C_API truss_message* truss_load_file(const char* filename);
 TRUSS_C_API int truss_save_file(const char* filename, truss_message* data);
 TRUSS_C_API int truss_save_data(const char* filename, const char* data, unsigned int datalength);
-TRUSS_C_API int truss_add_fs_path(const char* path, const char* mountpath, int append);
+TRUSS_C_API int truss_add_fs_path(const char* path, const char* mountpath, int append, int relative);
 TRUSS_C_API int truss_set_fs_savedir(const char* path);
 TRUSS_C_API int truss_set_raw_write_dir(const char* path);
 TRUSS_C_API int truss_list_directory(truss_interpreter_id interpreter, const char* path);


### PR DESCRIPTION
* `truss.add_fs_path` now takes a 'relative' argument to whether the path should be relative to the base dir (directory of the binary).

* Now SDL doesn't initialize until a window is created, which might prevent some problems on headless systems.